### PR TITLE
Fixed Bug: 'main' entry in the package.json file was pointing to the wrong file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ocr-space-api-alt2",
   "version": "2.0.1",
   "description": "Fork of Dennnisk's original ocr-space-api with added support for PDF uploading. Provides an easy way to send images to the ocr.space API and get the OCR Result",
-  "main": "lib/ocrSpaceApi.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "node example/example.js",
     "release": "standard-version",


### PR DESCRIPTION
The 'main' entry in the package.json file was pointing to the wrong file, 'lib/ocrSpaceApi.js', instead of the correct file 'lib/index.js'. This resulted in incorrect behavior when executing the package. This commit fixes the error by updating the 'main' field in the package.json file to correctly point to 'lib/ocrSpaceApi.js', which is the intended entry point file. Additionally, I verified that the 'lib' directory exists and contains the necessary 'index.js' file as the correct entry point for the package. This commit ensures that the package can be properly imported and executed with the correct entry point file specified in the 'main' field.
